### PR TITLE
Include git lightweight tags for version detection

### DIFF
--- a/cmake/GitVersion.cmake
+++ b/cmake/GitVersion.cmake
@@ -24,7 +24,7 @@ function(GetGitVersion _prefix)
   set (ret 1)
 
   if(GIT_FOUND)
-    execute_process(COMMAND ${GIT_EXECUTABLE} describe 
+    execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags 
       RESULT_VARIABLE ret OUTPUT_VARIABLE str OUTPUT_STRIP_TRAILING_WHITESPACE 
       ERROR_QUIET)
   endif()


### PR DESCRIPTION
`GitVersion.cmake` uses `git describe` to detect the application version.

By default, Git reads only annotated tags. The git repo currently contains a few version tags, but they're all lighweight tags, none of them is annotated. Thus, the version detection fails and the resulting version (`mbpoll -V`) is always `1.0-0`.

Git may be advised to handle lightweight tags by setting the argument `--tags`. This results in a proper version, e.g. `1.4-11` for the current master branch ([1968de6](https://github.com/git-developer/mbpoll/commit/1968de6b92fff20f57019551b1e8776a6facf486)).